### PR TITLE
Support regex in slashCommandName

### DIFF
--- a/src/Handlers/SignatureHandler.php
+++ b/src/Handlers/SignatureHandler.php
@@ -3,6 +3,7 @@
 namespace Spatie\SlashCommand\Handlers;
 
 use Illuminate\Console\Parser;
+use Illuminate\Support\Str;
 use Spatie\SlashCommand\Exceptions\InvalidHandler;
 use Spatie\SlashCommand\Request;
 use Symfony\Component\Console\Exception\RuntimeException;
@@ -59,7 +60,8 @@ abstract class SignatureHandler extends BaseHandler
 
         $signatureParts = new SignatureParts($this->signature);
 
-        if ($request->command != $signatureParts->getSlashCommandName()) {
+
+        if (! Str::is($signatureParts->getSlashCommandName(), $request->command)) {
             return false;
         }
 


### PR DESCRIPTION
Potential fix for #12 

Instead 
```php
protected $signature = 'paolo dns {domain}';
```
Now also allows:
```php
protected $signature = '* dns {domain}';
```
Or
```php
protected $signature = 'p* dns {domain}';
```

Allows for sharing of commands, independ of  the slashname.