### PR TITLE
Create Help command

### DIFF
--- a/src/Handlers/Help.php
+++ b/src/Handlers/Help.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Spatie\SlashCommand\Handlers;
+
+use Illuminate\Support\Str;
+use Spatie\SlashCommand\Attachment;
+use Spatie\SlashCommand\AttachmentField;
+use Spatie\SlashCommand\HandlesSlashCommand;
+use Spatie\SlashCommand\Request;
+use Spatie\SlashCommand\Response;
+
+class Help extends BaseHandler
+{
+
+    /**
+     * Check if the command begins with 'help'
+     *
+     * @param \Spatie\SlashCommand\Request $request
+     *
+     * @return bool
+     */
+    public function canHandle(Request $request): bool
+    {
+        return Str::startsWith($request->text, 'help');
+    }
+
+    /**
+     * Handle the given request.
+     *
+     * @param \Spatie\SlashCommand\Request $request
+     *
+     * @return \Spatie\SlashCommand\Response
+     */
+    public function handle(Request $request): Response
+    {
+        $command = trim(substr($this->request->text, 4));
+        $helpRequest = clone $this->request;
+        $helpRequest->text = $command;
+
+        $handlers = collect(config('laravel-slack-slash-command.handlers'))
+            ->map(function (string $handlerClassName) use($helpRequest) {
+                return new $handlerClassName($helpRequest);
+            })
+            ->filter(function (HandlesSlashCommand $handler) use ($helpRequest){
+                if ($handler instanceof SignatureHandler && isset($handler->signature)) {
+                    $signatureParts = new SignatureParts($handler->signature);
+                    return in_array($signatureParts->getSlashCommandName(), [$this->request->command, '*']);
+                }
+            });
+
+        // When command is passed, find all commands
+        if (! empty($command)) {
+
+            /** @var SignatureHandler $handler */
+            $handler = $handlers
+                ->filter(function (HandlesSlashCommand $handler) use ($helpRequest){
+                    return $handler->canHandle($helpRequest);
+                })
+                ->first();
+
+            $signature = $this->formatSignature($handler->signature);
+
+            return $this->respondToSlack("Usage for command */{$this->request->command} {$command}*")
+                ->withAttachment(Attachment::create()->setText($signature));
+        } else {
+            // Create AttachmentFields for each handler
+            $attachmentFields = collect($handlers)->reduce(function (array $attachmentFields, SignatureHandler $handler) {
+
+                $signature = $this->formatSignature($handler->signature);
+                $signatureParts = new SignatureParts($signature);
+                $attachmentFields[] = AttachmentField::create($signatureParts->getHandlerName(), $signature);
+
+                return $attachmentFields;
+            }, []);
+
+            return $this->respondToSlack("Listing all commands available for */{$this->request->command}*:")
+                ->withAttachment(Attachment::create()
+                    ->setFields($attachmentFields)
+                );
+        }
+    }
+
+    protected function formatSignature($signature)
+    {
+        $signatureParts = new SignatureParts($signature);
+        return '/' . $this->request->command . ' ' . $signatureParts->getSignatureWithoutCommandName();
+    }
+}

--- a/src/Handlers/SignatureHandler.php
+++ b/src/Handlers/SignatureHandler.php
@@ -5,9 +5,12 @@ namespace Spatie\SlashCommand\Handlers;
 use Illuminate\Console\Parser;
 use Spatie\SlashCommand\Exceptions\InvalidHandler;
 use Spatie\SlashCommand\Request;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Helper\DescriptorHelper;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\BufferedOutput;
 
 abstract class SignatureHandler extends BaseHandler
 {
@@ -70,9 +73,37 @@ abstract class SignatureHandler extends BaseHandler
         return $this->input->getOptions();
     }
 
-    public function getInputDefinition(): InputDefinition
+    /**
+     * Get the full command (eg. `/bot ping`)
+     *
+     * @return string
+     */
+    public function getFullCommand(): string
     {
-        return $this->inputDefinition;
+        return '/' . $this->request->command . ' ' . $this->name;
+    }
+
+    /**
+     * Get the usage description, including parameters and options
+     *
+     * @return string
+     */
+    public function getHelpDescription(): string
+    {
+        $inputDefinition = $this->inputDefinition;
+        $output = new BufferedOutput();
+
+        $name = '/' . $this->request->command . ' ' . $this->name;
+
+        $command = (new Command($name))
+            ->setDefinition($inputDefinition)
+            ->setDescription($this->getDescription())
+        ;
+
+        $descriptor = new DescriptorHelper();
+        $descriptor->describe($output, $command);
+
+        return $output->fetch();
     }
 
     public function canHandle(Request $request): bool

--- a/src/Handlers/SignatureHandler.php
+++ b/src/Handlers/SignatureHandler.php
@@ -14,8 +14,17 @@ abstract class SignatureHandler extends BaseHandler
     /** @var string */
     protected $name;
 
+    /** @var string */
+    protected $signature;
+
+    /** @var string */
+    protected $description;
+
     /** @var \Symfony\Component\Console\Input\StringInput */
     protected $input;
+
+    /** @var \Symfony\Component\Console\Input\InputDefinition */
+    protected $inputDefinition;
 
     /** @var bool */
     protected $signatureIsBound;
@@ -29,6 +38,16 @@ abstract class SignatureHandler extends BaseHandler
         }
 
         $this->signatureIsBound = $this->bindSignature($this->signature);
+    }
+
+    public function getSignature(): string
+    {
+        return $this->signature;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description ?: '';
     }
 
     public function getArgument($foo)
@@ -49,6 +68,11 @@ abstract class SignatureHandler extends BaseHandler
     public function getOptions(): array
     {
         return $this->input->getOptions();
+    }
+
+    public function getInputDefinition(): InputDefinition
+    {
+        return $this->inputDefinition;
     }
 
     public function canHandle(Request $request): bool
@@ -93,6 +117,7 @@ abstract class SignatureHandler extends BaseHandler
         $inputWithoutHandlerName = explode(' ', $this->request->text, 2)[1] ?? '';
 
         $this->input = new StringInput($inputWithoutHandlerName);
+        $this->inputDefinition = $inputDefinition;
 
         try {
             $this->input->bind($inputDefinition);


### PR DESCRIPTION
According to https://api.slack.com/slash-commands#best_practices it is best to create a help function. This creates that, for the SignatureHandlers. Requires the signature to be public.

Ideas for improvement:
 - Add a command name/description for each handler, like the Console, to show all commands.
 - Use the Console Descriptor to generate extensive documentation based on the signature parts.