### PR TITLE
Expose validate for Handler

### DIFF
--- a/src/Handlers/SignatureHandler.php
+++ b/src/Handlers/SignatureHandler.php
@@ -104,4 +104,24 @@ abstract class SignatureHandler extends BaseHandler
 
         return true;
     }
+    
+        /**
+     * @return Response|null
+     */
+    protected function validate()
+    {
+        try {
+            $this->input->validate();
+        } catch (RuntimeException $e) {
+            return $this->respondToSlack('')->withAttachment(
+                Attachment::create()
+                    ->setColor('danger')
+                    ->setText($e->getMessage())
+                )
+                ->withAttachment(
+                    Attachment::create()
+                    ->setText($this->getHelpDescription())
+                );
+        }
+    }
 }


### PR DESCRIPTION
Adds a method to validate a request. Could also have been default, but not possible because of BC.

Example:

```php
public function handle(Request $request): Response
{
    if ($errorResponse = $this->validate()) {
        return $errorResponse;
    }

    $site = $this->getArgument('site');

    // ...
}
```

![image](https://cloud.githubusercontent.com/assets/973269/19068323/88408edc-8a22-11e6-88a3-67f61317e4a5.png)
