### PR TITLE
Convert exceptions to Slack responses

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -8,6 +8,7 @@ use Illuminate\Http\Response as IlluminateResponse;
 use Illuminate\Routing\Controller as IlluminateController;
 use Spatie\SlashCommand\Exceptions\InvalidHandler;
 use Spatie\SlashCommand\Exceptions\InvalidRequest;
+use Spatie\SlashCommand\Exceptions\SlashException;
 use Spatie\SlashCommand\Exceptions\RequestCouldNotBeHandled;
 
 class Controller extends IlluminateController
@@ -31,7 +32,11 @@ class Controller extends IlluminateController
 
         $handler = $this->determineHandler();
 
-        $response = $handler->handle($this->request);
+        try {
+            $response = $handler->handle($this->request);
+        } catch (SlashException $e) {
+            $response = $e->getResponse($this->request);
+        }
 
         return $response->getIlluminateResponse();
     }

--- a/src/Exceptions/FieldCannotBeAdded.php
+++ b/src/Exceptions/FieldCannotBeAdded.php
@@ -2,10 +2,9 @@
 
 namespace Spatie\SlashCommand\Exceptions;
 
-use Exception;
 use Spatie\SlashCommand\AttachmentField;
 
-class FieldCannotBeAdded extends Exception
+class FieldCannotBeAdded extends SlashException
 {
     public static function invalidType()
     {

--- a/src/Exceptions/InvalidHandler.php
+++ b/src/Exceptions/InvalidHandler.php
@@ -2,10 +2,9 @@
 
 namespace Spatie\SlashCommand\Exceptions;
 
-use Exception;
 use Spatie\SlashCommand\Handlers\BaseHandler;
 
-class InvalidHandler extends Exception
+class InvalidHandler extends SlashException
 {
     public static function handlerDoesNotExist($handler)
     {

--- a/src/Exceptions/InvalidInput.php
+++ b/src/Exceptions/InvalidInput.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Spatie\SlashCommand\Exceptions;
+
+use Exception;
+use Spatie\SlashCommand\Attachment;
+use Spatie\SlashCommand\Request;
+use Spatie\SlashCommand\Response;
+use Spatie\SlashCommand\Handlers\SignatureHandler;
+
+class InvalidInput extends SlashException
+{
+    protected $handler;
+
+    public function __construct($message, SignatureHandler $handler, Exception $previous = null)
+    {
+        parent::__construct($message, 0, $previous);
+
+        $this->handler = $handler;
+    }
+
+    public function getResponse(Request $request): Response
+    {
+        return parent::getResponse($request)
+            ->withAttachment(
+                Attachment::create()
+                    ->setText($this->handler->getHelpDescription())
+            );
+    }
+}

--- a/src/Exceptions/InvalidRequest.php
+++ b/src/Exceptions/InvalidRequest.php
@@ -2,9 +2,7 @@
 
 namespace Spatie\SlashCommand\Exceptions;
 
-use Exception;
-
-class InvalidRequest extends Exception
+class InvalidRequest extends SlashException
 {
     public static function tokenNotFound()
     {

--- a/src/Exceptions/InvalidSignature.php
+++ b/src/Exceptions/InvalidSignature.php
@@ -2,9 +2,7 @@
 
 namespace Spatie\SlashCommand\Exceptions;
 
-use Exception;
-
-class InvalidSignature extends Exception
+class InvalidSignature extends SlashException
 {
     public static function signatureMustContainASpace($signature)
     {

--- a/src/Exceptions/RequestCouldNotBeHandled.php
+++ b/src/Exceptions/RequestCouldNotBeHandled.php
@@ -2,10 +2,9 @@
 
 namespace Spatie\SlashCommand\Exceptions;
 
-use Exception;
 use Spatie\SlashCommand\Request;
 
-class RequestCouldNotBeHandled extends Exception
+class RequestCouldNotBeHandled extends SlashException
 {
     public static function noHandlerFound(Request $request)
     {

--- a/src/Exceptions/SlashException.php
+++ b/src/Exceptions/SlashException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Spatie\SlashCommand\Exceptions;
+
+use Exception;
+use Spatie\SlashCommand\Attachment;
+use Spatie\SlashCommand\Request;
+use Spatie\SlashCommand\Response;
+
+class SlashException extends Exception
+{
+    public function getResponse(Request $request): Response
+    {
+        return Response::create($request)
+            ->withAttachment(Attachment::create()
+                ->setText($this->getMessage())
+                ->setFallback($this->getMessage())
+                ->setColor('danger')
+            );
+    }
+}

--- a/src/Handlers/BaseHandler.php
+++ b/src/Handlers/BaseHandler.php
@@ -4,6 +4,7 @@ namespace Spatie\SlashCommand\Handlers;
 
 use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Foundation\Bus\DispatchesJobs;
+use Spatie\SlashCommand\Exceptions\SlashException;
 use Spatie\SlashCommand\HandlesSlashCommand;
 use Spatie\SlashCommand\Jobs\SlashCommandResponseJob;
 use Spatie\SlashCommand\Request;
@@ -31,6 +32,11 @@ abstract class BaseHandler implements HandlesSlashCommand
         $job->setRequest($this->request);
 
         return app(Dispatcher::class)->dispatch($job);
+    }
+
+    protected function abort($response)
+    {
+        throw new SlashException($response);
     }
 
     public function getRequest(): Request

--- a/src/Handlers/SignatureHandler.php
+++ b/src/Handlers/SignatureHandler.php
@@ -5,6 +5,7 @@ namespace Spatie\SlashCommand\Handlers;
 use Illuminate\Console\Parser;
 use Illuminate\Support\Str;
 use Spatie\SlashCommand\Exceptions\InvalidHandler;
+use Spatie\SlashCommand\Exceptions\InvalidInput;
 use Spatie\SlashCommand\Request;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Input\InputDefinition;
@@ -103,5 +104,14 @@ abstract class SignatureHandler extends BaseHandler
         }
 
         return true;
+    }
+
+    protected function validate()
+    {
+        try {
+            $this->input->validate();
+        } catch (RuntimeException $e) {
+            throw new InvalidInput($e->getMessage(), $this, $e);
+        }
     }
 }


### PR DESCRIPTION
Alternative for #18

- Create base SlackException which can convert exceptions to response
- Catch responses in controller to return nicer errors
- add $handler->abort($msg) to abort a command anywhere in the Handler (like Laravels abort())
- Convert error on input validation, to check the signature.