### PR TITLE
Fix error when calling setFields with an array

### DIFF
--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -358,7 +358,7 @@ class Attachment
          }
 
          if (is_array($key) && is_null($value)) {
-             array_map(function($value, $index) {
+             array_map(function ($value, $index) {
                  $this->fields->push(AttachmentField::create($index, $value));
              }, $value, array_keys($value));
 

--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -324,55 +324,40 @@ class Attachment
     }
 
     /**
-     * Set the fields for the attachment.
-     *
-     * @param array $fields
-     *
-     * @return $this
-     */
-    public function setFields(array $fields)
+    * Add a field to the attachment.
+    *
+    * @param \Spatie\SlashCommand\AttachmentField|array|string $key
+    * @param null|string $value
+    *
+    * @return $this
+    *
+    * @throws \Spatie\SlashCommand\Exceptions\FieldCannotBeAdded
+    */
+    public function addField($key, $value = null)
     {
-        $this->clearFields();
+        if (! is_array($key) && ! $key instanceof AttachmentField && is_null($value)) {
+            throw FieldCannotBeAdded::invalidType();
+        }
 
-        collect($fields)->each(function ($key, $field) {
-            $this->addField($key, $field);
-        });
+        if (is_array($key) && $value !== '') {
+            array_map(function ($value, $index) {
+                $this->fields->push(AttachmentField::create($index, $value));
+            }, $key, array_keys($key));
+
+            return $this;
+        }
+
+        if (! $key instanceof AttachmentField && ! is_array($key)) {
+            $this->fields->push(AttachmentField::create($key, $value));
+
+            return $this;
+        }
+
+        var_dump($key);exit;
+        $this->fields->push($key);
 
         return $this;
     }
-
-    /**
-     * Add a field to the attachment.
-     *
-     * @param \Spatie\SlashCommand\AttachmentField|string $key
-     * @param null|string $value
-     *
-     * @return $this
-     *
-     * @throws \Spatie\SlashCommand\Exceptions\FieldCannotBeAdded
-     */
-     public function addField($key, $value = null)
-     {
-         if (! is_array($key) && ! $key instanceof AttachmentField && is_null($value)) {
-             throw FieldCannotBeAdded::invalidType();
-         }
-
-         if (is_array($key) && is_null($value)) {
-             array_map(function ($value, $index) {
-                 $this->fields->push(AttachmentField::create($index, $value));
-             }, $value, array_keys($value));
-
-             return $this;
-         }
-
-         if (!$key instanceof AttachmentField) {
-             $this->fields->push(AttachmentField::create($key, $value));
-         }
-
-         $this->fields->push($key);
-
-         return $this;
-     }
 
     /**
      * Clear all fields for this attachment.

--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -334,8 +334,8 @@ class Attachment
     {
         $this->clearFields();
 
-        collect($fields)->each(function ($field) {
-            $this->addField($field);
+        collect($fields)->each(function ($key, $field) {
+            $this->addField($key, $field);
         });
 
         return $this;
@@ -344,23 +344,28 @@ class Attachment
     /**
      * Add a field to the attachment.
      *
-     * @param \Spatie\SlashCommand\AttachmentField|array $field
+     * @param \Spatie\SlashCommand\AttachmentField|string $key
+     * @param null|string $value
      *
      * @return $this
      *
      * @throws \Spatie\SlashCommand\Exceptions\FieldCannotBeAdded
      */
-    public function addField($field)
+    public function addField($key, $value = null)
     {
-        if (! is_array($field) && ! $field instanceof AttachmentField) {
+        if (! is_array($key) && ! $key instanceof AttachmentField && is_null($value)) {
             throw FieldCannotBeAdded::invalidType();
         }
 
-        if (is_array($field)) {
-            $field = AttachmentField::create($field);
+        if (is_array($key) && is_null($value)) {
+            array_map(function($value, $index) {
+                $this->fields->push(AttachmentField::create($index, $value));
+            }, $value, array_keys($value));
+
+            return $this;
         }
 
-        $this->fields->push($field);
+        $this->fields->push(AttachmentField::create($key, $value));
 
         return $this;
     }

--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -334,7 +334,7 @@ class Attachment
     {
         $this->clearFields();
 
-        collect($fields)->each(function ($key, $field) {
+        collect($fields)->each(function ($field, $key) {
             $this->addField($key, $field);
         });
 
@@ -342,15 +342,15 @@ class Attachment
     }
 
     /**
-    * Add a field to the attachment.
-    *
-    * @param \Spatie\SlashCommand\AttachmentField|array|string $key
-    * @param null|string $value
-    *
-    * @return $this
-    *
-    * @throws \Spatie\SlashCommand\Exceptions\FieldCannotBeAdded
-    */
+     * Add a field to the attachment.
+     *
+     * @param \Spatie\SlashCommand\AttachmentField|array|string $key
+     * @param null|string $value
+     *
+     * @return $this
+     *
+     * @throws \Spatie\SlashCommand\Exceptions\FieldCannotBeAdded
+     */
     public function addField($key, $value = null)
     {
         if (! is_array($key) && ! $key instanceof AttachmentField && is_null($value)) {

--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -351,24 +351,28 @@ class Attachment
      *
      * @throws \Spatie\SlashCommand\Exceptions\FieldCannotBeAdded
      */
-    public function addField($key, $value = null)
-    {
-        if (! is_array($key) && ! $key instanceof AttachmentField && is_null($value)) {
-            throw FieldCannotBeAdded::invalidType();
-        }
+     public function addField($key, $value = null)
+     {
+         if (! is_array($key) && ! $key instanceof AttachmentField && is_null($value)) {
+             throw FieldCannotBeAdded::invalidType();
+         }
 
-        if (is_array($key) && is_null($value)) {
-            array_map(function($value, $index) {
-                $this->fields->push(AttachmentField::create($index, $value));
-            }, $value, array_keys($value));
+         if (is_array($key) && is_null($value)) {
+             array_map(function($value, $index) {
+                 $this->fields->push(AttachmentField::create($index, $value));
+             }, $value, array_keys($value));
 
-            return $this;
-        }
+             return $this;
+         }
 
-        $this->fields->push(AttachmentField::create($key, $value));
+         if (!$key instanceof AttachmentField) {
+             $this->fields->push(AttachmentField::create($key, $value));
+         }
 
-        return $this;
-    }
+         $this->fields->push($key);
+
+         return $this;
+     }
 
     /**
      * Clear all fields for this attachment.

--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -371,7 +371,6 @@ class Attachment
             return $this;
         }
 
-        var_dump($key);exit;
         $this->fields->push($key);
 
         return $this;

--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -324,6 +324,24 @@ class Attachment
     }
 
     /**
+     * Set the fields for the attachment.
+     *
+     * @param array $fields
+     *
+     * @return $this
+     */
+    public function setFields(array $fields)
+    {
+        $this->clearFields();
+
+        collect($fields)->each(function ($key, $field) {
+            $this->addField($key, $field);
+        });
+
+        return $this;
+    }
+
+    /**
     * Add a field to the attachment.
     *
     * @param \Spatie\SlashCommand\AttachmentField|array|string $key


### PR DESCRIPTION
fix error "You must pass either an array or an instance of Spatie\SlashCommand\AttachmentField" in setFields method.

The error is caused by a incompatible signature on addField method
