### PR TITLE
spelling fixes

### DIFF
--- a/config/laravel-slack-slash-command.php
+++ b/config/laravel-slack-slash-command.php
@@ -3,8 +3,8 @@
 return [
 
     /*
-     * Over at Slack you can configure to which url the slack commands must be send.
-     * url here. You must specify that. Be sure to leave of the domain name.
+     * In Slack Integration Settings you can configure URL to which the slack commands are POSTed.
+     * Specify the PATH component of your URL. for http://example.com/slack the value would be 'slack' here.
      */
     'url' => 'slack',
 


### PR DESCRIPTION
actually reword the whole thing to be understandable.

i hard very hard time trying to understand what that line supposed to be and what the comments tried to say. i've figured out finally just by expermenting and filled `/` there as my handler is in host root as i'm using  https://localtunnel.me for testing.

please note that everywhere in documentation and in blog post the same error is there (using word `of` instead of `off` which is the source of most confusion)

also, ideally the parameter should be named `'path'` rather than `'url'` to be more accurate, and should specify what to fill if root path is present, should one fill there empty string (`''`) or just forward slash (`'/'`)