### PR TITLE
Allow for attachments to have actions

### DIFF
--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -450,6 +450,34 @@ class Attachment
     }
 
     /**
+     * Set the actions for the attachment.
+     *
+     * @param array $actions
+     *
+     * @return $this
+     */
+    public function setActions(array $actions)
+    {
+        $this->clearActions();
+
+        $this->addActions($actions);
+
+        return $this;
+    }
+
+    /**
+     * Clear all actions for this attachment.
+     *
+     * @return $this
+     */
+    public function clearActions()
+    {
+        $this->actions = new Collection();
+
+        return $this;
+    }
+
+    /**
      * Convert this attachment to its array representation.
      *
      * @return array

--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -434,6 +434,22 @@ class Attachment
     }
 
     /**
+     * Add the actions for the attachment.
+     *
+     * @param array $actions
+     *
+     * @return $this
+     */
+    public function addActions(array $actions)
+    {
+        collect($actions)->each(function ($action) {
+            $this->addAction($action);
+        });
+
+        return $this;
+    }
+
+    /**
      * Convert this attachment to its array representation.
      *
      * @return array

--- a/src/AttachmentAction.php
+++ b/src/AttachmentAction.php
@@ -25,6 +25,14 @@ class AttachmentAction
      */
     protected $type;
 
+
+    /**
+     * The value of the action.
+     *
+     * @var string
+     */
+    protected $value = '';
+
     public static function create($name, $text, $type)
     {
         return new static($name, $text, $type);
@@ -80,6 +88,20 @@ class AttachmentAction
     }
 
     /**
+     * Set the value of the action.
+     *
+     * @param string $value
+     *
+     * @return AttachmentAction
+     */
+    public function setValue(string $value): AttachmentAction
+    {
+        $this->value = $value;
+
+        return $this;
+    }
+
+    /**
      * Convert this action to its array representation.
      *
      * @return array
@@ -90,6 +112,7 @@ class AttachmentAction
             'name' => $this->name,
             'text' => $this->text,
             'type' => $this->type,
+            'value' => $this->value,
         ];
     }
 }

--- a/src/AttachmentAction.php
+++ b/src/AttachmentAction.php
@@ -2,6 +2,8 @@
 
 namespace Spatie\SlashCommand;
 
+use Spatie\SlashCommand\Exceptions\InvalidConfirmationHash;
+
 class AttachmentAction
 {
     const STYLE_DEFAULT = 'default';
@@ -42,6 +44,14 @@ class AttachmentAction
      * @var string
      */
     protected $style = self::STYLE_DEFAULT;
+
+    /**
+     * An optional confirmation
+     * dialog for the action
+     *
+     * @var null|array
+     */
+    protected $confirmation = null;
 
     public static function create($name, $text, $type)
     {
@@ -126,6 +136,25 @@ class AttachmentAction
     }
 
     /**
+     * Sets the confirmation hash for the action.
+     *
+     * @param array $confirmation
+     *
+     * @return \Spatie\SlashCommand\AttachmentAction
+     * @throws \Spatie\SlashCommand\Exceptions\InvalidConfirmationHash
+     */
+    public function setConfirmation(array $confirmation)
+    {
+        if (!array_key_exists('text', $confirmation)) {
+            throw InvalidConfirmationHash::missingTextField();
+        }
+
+        $this->confirmation = $confirmation;
+
+        return $this;
+    }
+
+    /**
      * Convert this action to its array representation.
      *
      * @return array
@@ -138,6 +167,7 @@ class AttachmentAction
             'type' => $this->type,
             'value' => $this->value,
             'style' => $this->style,
+            'confirm' => $this->confirmation,
         ];
     }
 }

--- a/src/AttachmentAction.php
+++ b/src/AttachmentAction.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Spatie\SlashCommand;
+
+class AttachmentAction
+{
+    /**
+     * The required name field of the action.
+     *
+     * @var string
+     */
+    private $name;
+
+    /**
+     * The required text field of the action.
+     *
+     * @var string
+     */
+    private $text;
+
+    /**
+     * The required type field of the action.
+     *
+     * @var string
+     */
+    private $type;
+
+    public static function create($name, $text, $type)
+    {
+        return new static($name, $text, $type);
+    }
+
+    public function __construct(string $name, string $text, string $type)
+    {
+        $this->name = $name;
+        $this->text = $text;
+        $this->type = $type;
+    }
+
+    /**
+     * Convert this action to its array representation.
+     *
+     * @return array
+     */
+    public function toArray(): array
+    {
+        return [
+            'name' => $this->name,
+            'text' => $this->text,
+            'type' => $this->type,
+        ];
+    }
+}

--- a/src/AttachmentAction.php
+++ b/src/AttachmentAction.php
@@ -9,21 +9,21 @@ class AttachmentAction
      *
      * @var string
      */
-    private $name;
+    protected $name;
 
     /**
      * The required text field of the action.
      *
      * @var string
      */
-    private $text;
+    protected $text;
 
     /**
      * The required type field of the action.
      *
      * @var string
      */
-    private $type;
+    protected $type;
 
     public static function create($name, $text, $type)
     {

--- a/src/AttachmentAction.php
+++ b/src/AttachmentAction.php
@@ -38,6 +38,48 @@ class AttachmentAction
     }
 
     /**
+     * Set the name of the action.
+     *
+     * @param string $name
+     *
+     * @return AttachmentAction
+     */
+    public function setName(string $name): AttachmentAction
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * Set the text of the action.
+     *
+     * @param string $text
+     *
+     * @return AttachmentAction
+     */
+    public function setText(string $text): AttachmentAction
+    {
+        $this->text = $text;
+
+        return $this;
+    }
+
+    /**
+     * Set the type of the action.
+     *
+     * @param string $type
+     *
+     * @return AttachmentAction
+     */
+    public function setType(string $type): AttachmentAction
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    /**
      * Convert this action to its array representation.
      *
      * @return array

--- a/src/AttachmentAction.php
+++ b/src/AttachmentAction.php
@@ -4,6 +4,10 @@ namespace Spatie\SlashCommand;
 
 class AttachmentAction
 {
+    const STYLE_DEFAULT = 'default';
+    const STYLE_PRIMARY = 'primary';
+    const STYLE_DANGER = 'danger';
+
     /**
      * The required name field of the action.
      *
@@ -25,13 +29,19 @@ class AttachmentAction
      */
     protected $type;
 
-
     /**
      * The value of the action.
      *
      * @var string
      */
     protected $value = '';
+
+    /**
+     * The style of the action.
+     *
+     * @var string
+     */
+    protected $style = self::STYLE_DEFAULT;
 
     public static function create($name, $text, $type)
     {
@@ -102,6 +112,20 @@ class AttachmentAction
     }
 
     /**
+     * Set the style of the action.
+     *
+     * @param string $style
+     *
+     * @return AttachmentAction
+     */
+    public function setStyle(string $style): AttachmentAction
+    {
+        $this->style = $style;
+
+        return $this;
+    }
+
+    /**
      * Convert this action to its array representation.
      *
      * @return array
@@ -113,6 +137,7 @@ class AttachmentAction
             'text' => $this->text,
             'type' => $this->type,
             'value' => $this->value,
+            'style' => $this->style,
         ];
     }
 }

--- a/src/Exceptions/ActionCannotBeAdded.php
+++ b/src/Exceptions/ActionCannotBeAdded.php
@@ -1,0 +1,11 @@
+<?php namespace Spatie\SlashCommand\Exceptions;
+
+use Spatie\SlashCommand\AttachmentAction;
+
+class ActionCannotBeAdded extends SlackSlashCommandException
+{
+    public static function invalidType()
+    {
+        return new static('You must pass either an array or an instance of '.AttachmentAction::class);
+    }
+}

--- a/src/Exceptions/InvalidConfirmationHash.php
+++ b/src/Exceptions/InvalidConfirmationHash.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Spatie\SlashCommand\Exceptions;
+
+class InvalidConfirmationHash extends SlackSlashCommandException
+{
+    public static function missingTextField()
+    {
+        return new self('The confirmation hash is missing the text field.');
+    }
+}

--- a/tests/AttachmentActionTest.php
+++ b/tests/AttachmentActionTest.php
@@ -33,4 +33,17 @@ class AttachmentActionTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('button', $action['type']);
         $this->assertSame('primary', $action['style']);
     }
+
+    public function it_can_set_a_confirmation_hash()
+    {
+        $attachmentAction = AttachmentAction::create('action', 'an action', 'button')
+                                            ->setConfirmation(['text' => 'are you sure you want to do that?']);
+
+        $action = $attachmentAction->toArray();
+
+        $this->assertSame('action', $action['name']);
+        $this->assertSame('an action', $action['text']);
+        $this->assertSame('button', $action['type']);
+        $this->assertSame(['text' => 'are you sure you want to do that?'], $action['confirm']);
+    }
 }

--- a/tests/AttachmentActionTest.php
+++ b/tests/AttachmentActionTest.php
@@ -19,4 +19,18 @@ class AttachmentActionTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('button', $action['type']);
         $this->assertSame('value', $action['value']);
     }
+
+    /** @test */
+    public function test_it_can_set_a_style()
+    {
+        $attachmentAction = AttachmentAction::create('action', 'an action', 'button')
+                                            ->setStyle(AttachmentAction::STYLE_PRIMARY);
+
+        $action = $attachmentAction->toArray();
+
+        $this->assertSame('action', $action['name']);
+        $this->assertSame('an action', $action['text']);
+        $this->assertSame('button', $action['type']);
+        $this->assertSame('primary', $action['style']);
+    }
 }

--- a/tests/AttachmentActionTest.php
+++ b/tests/AttachmentActionTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Spatie\SlashCommand\Test;
+
+use Spatie\SlashCommand\AttachmentAction;
+
+class AttachmentActionTest extends \PHPUnit_Framework_TestCase
+{
+    /** @test */
+    public function test_it_can_set_a_value()
+    {
+        $attachmentAction = AttachmentAction::create('action', 'an action', 'button')
+                                            ->setValue('value');
+
+        $action = $attachmentAction->toArray();
+
+        $this->assertSame('action', $action['name']);
+        $this->assertSame('an action', $action['text']);
+        $this->assertSame('button', $action['type']);
+        $this->assertSame('value', $action['value']);
+    }
+}

--- a/tests/AttachmentActionTest.php
+++ b/tests/AttachmentActionTest.php
@@ -7,7 +7,7 @@ use Spatie\SlashCommand\AttachmentAction;
 class AttachmentActionTest extends \PHPUnit_Framework_TestCase
 {
     /** @test */
-    public function test_it_can_set_a_value()
+    public function it_can_set_a_value()
     {
         $attachmentAction = AttachmentAction::create('action', 'an action', 'button')
                                             ->setValue('value');
@@ -21,7 +21,7 @@ class AttachmentActionTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
-    public function test_it_can_set_a_style()
+    public function it_can_set_a_style()
     {
         $attachmentAction = AttachmentAction::create('action', 'an action', 'button')
                                             ->setStyle(AttachmentAction::STYLE_PRIMARY);

--- a/tests/AttachmentTest.php
+++ b/tests/AttachmentTest.php
@@ -67,4 +67,23 @@ class AttachmentTest extends TestCase
         $this->assertSame('a button', $action['text']);
         $this->assertSame('button', $action['type']);
     }
+
+    /** @test */
+    public function it_can_add_multiple_actions_using_an_associative_array()
+    {
+        $this->attachment->addActions([
+            ['name' => 'button1', 'text' => 'button1', 'type' => 'button'],
+            ['name' => 'button2', 'text' => 'button2', 'type' => 'button'],
+        ]);
+
+        $attachments = $this->attachment->toArray()['actions'];
+
+        $this->assertEquals('button1', $attachments[0]['name']);
+        $this->assertEquals('button1', $attachments[0]['text']);
+        $this->assertEquals('button', $attachments[0]['type']);
+
+        $this->assertEquals('button2', $attachments[1]['name']);
+        $this->assertEquals('button2', $attachments[1]['text']);
+        $this->assertEquals('button', $attachments[1]['type']);
+    }
 }

--- a/tests/AttachmentTest.php
+++ b/tests/AttachmentTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\SlashCommand\Test;
 
 use Spatie\SlashCommand\Attachment;
+use Spatie\SlashCommand\AttachmentAction;
 use Spatie\SlashCommand\AttachmentField;
 
 class AttachmentTest extends TestCase
@@ -85,5 +86,19 @@ class AttachmentTest extends TestCase
         $this->assertEquals('button2', $attachments[1]['name']);
         $this->assertEquals('button2', $attachments[1]['text']);
         $this->assertEquals('button', $attachments[1]['type']);
+    }
+
+    /** @test */
+    public function it_can_add_an_array_of_attachment_actions()
+    {
+        $attachmentAction = AttachmentAction::create('action', 'click me', 'button');
+
+        $this->attachment->addActions([$attachmentAction]);
+
+        $actions = $this->attachment->toArray()['actions'];
+
+        $this->assertSame('action', $actions[0]['name']);
+        $this->assertSame('click me', $actions[0]['text']);
+        $this->assertSame('button', $actions[0]['type']);
     }
 }

--- a/tests/AttachmentTest.php
+++ b/tests/AttachmentTest.php
@@ -55,4 +55,16 @@ class AttachmentTest extends TestCase
         $this->assertEquals('title', $attachments[0]['title']);
         $this->assertEquals('value', $attachments[0]['value']);
     }
+
+    /** @test */
+    public function it_can_add_a_action()
+    {
+        $this->attachment->addAction(['name' => 'button', 'text' => 'a button', 'type' => 'button']);
+
+        $action = $this->attachment->toArray()['actions'][0];
+
+        $this->assertSame('button', $action['name']);
+        $this->assertSame('a button', $action['text']);
+        $this->assertSame('button', $action['type']);
+    }
 }

--- a/tests/Handlers/CatchAllTest.php
+++ b/tests/Handlers/CatchAllTest.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\SlashCommand\Test\Handlers;
 
-use Illuminate\Http\Response;
 use Spatie\SlashCommand\Test\TestCase;
 
 class CatchAllTest extends TestCase
@@ -19,12 +18,9 @@ class CatchAllTest extends TestCase
             'text' => $text,
         ]);
 
-        $this->assertInstanceOf(Response::class, $response);
-
-        $this->assertSame(200, $response->getStatusCode());
-
-        $responseContent = json_decode($response->getContent(), true);
-
-        $this->assertSame("I did not recognize this command: `{$command} {$text}`", $responseContent['text']);
+        $response->assertSuccessful();
+        $response->assertJsonFragment([
+            'text' => "I did not recognize this command: `{$command} {$text}`"
+        ]);
     }
 }


### PR DESCRIPTION
I needed this feature while using the package, and figured I'd extract my custom logic into a contribution back upstream. This feature aims to add the ability to add actions to an attachment, in basically the same fashion as you'd add fields.

Example:

```php
$attachment = Attachment::create()
        ->setColor('good')
        ->setText('This is good!')
        ->addAction(
            AttachmentAction::create('good', 'This is a good button!', 'button')
        )
```

I still need to add the ability to add menu actions, but those are significantly more involved. With that, I've got a couple of questions for the maintainers. 

* Would you like to keep a generic `AttachmentAction` that has all the abilities of both buttons and menus, or split the two off into a `Button` and `Menu` class.
* Would you like to keep the class name `AttachmentAction`, or instead change it to (FQCN) `\Spatie\SlashCommands\Attachment\Action`?