### PR TITLE
Support for Laravel 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
     ],
     "require": {
         "php" : "^7.0",
-        "illuminate/support": "~5.2.0|~5.3.0|~5.4.0",
-        "illuminate/routing": "~5.2.0|~5.3.0|~5.4.0",
-        "illuminate/config": "~5.2.0|~5.3.0|~5.4.0",
-        "illuminate/queue": "~5.2.0|~5.3.0|~5.4.0",
+        "illuminate/support": "~5.2.0|~5.3.0|~5.4.0|~5.5.0",
+        "illuminate/routing": "~5.2.0|~5.3.0|~5.4.0|~5.5.0",
+        "illuminate/config": "~5.2.0|~5.3.0|~5.4.0|~5.5.0",
+        "illuminate/queue": "~5.2.0|~5.3.0|~5.4.0|~5.5.0",
         "guzzlehttp/guzzle": "^6.2.1"
 
     },


### PR DESCRIPTION
Since the package got updated for Laravel 5.5's Auto-Discovery the require should also include that version.