### PR TITLE
Updated to Mockery 1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "require-dev": {
         "phpunit/phpunit": "5.*|6.*",
         "orchestra/testbench":  "~3.2.0|~3.3.0|~3.4.0|~3.5.0",
-        "mockery/mockery": "^0.9.5"
+        "mockery/mockery": "^1.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Updated `mockery/mockery` to [`^1.0`](https://github.com/mockery/mockery/releases/tag/1.0).

PS: I won't apply [this](https://styleci.io/analyses/q5E7wr) `StyleCI` changes. There are not related to this PR :sweat_smile: 
