### PR TITLE
add Laravel 5.6 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,16 +17,16 @@
     ],
     "require": {
         "php" : "^7.0",
-        "illuminate/support": "~5.2.0|~5.3.0|~5.4.0|~5.5.0",
-        "illuminate/routing": "~5.2.0|~5.3.0|~5.4.0|~5.5.0",
-        "illuminate/config": "~5.2.0|~5.3.0|~5.4.0|~5.5.0",
-        "illuminate/queue": "~5.2.0|~5.3.0|~5.4.0|~5.5.0",
+        "illuminate/support": "~5.2.0|~5.3.0|~5.4.0|~5.5.0|~5.6.0",
+        "illuminate/routing": "~5.2.0|~5.3.0|~5.4.0|~5.5.0|~5.6.0",
+        "illuminate/config": "~5.2.0|~5.3.0|~5.4.0|~5.5.0|~5.6.0",
+        "illuminate/queue": "~5.2.0|~5.3.0|~5.4.0|~5.5.0|~5.6.0",
         "guzzlehttp/guzzle": "^6.2.1"
 
     },
     "require-dev": {
-        "phpunit/phpunit": "5.*|6.*",
-        "orchestra/testbench":  "~3.2.0|~3.3.0|~3.4.0|~3.5.0",
+        "phpunit/phpunit": "5.*|6.*|7.*",
+        "orchestra/testbench":  "~3.2.0|~3.3.0|~3.4.0|~3.5.0|~3.6.0",
         "mockery/mockery": "^1.0"
     },
     "autoload": {


### PR DESCRIPTION
- Include version `~5.6.0` of `illuminate/*` dependencies in `composer.json`
- Allow installation of `phpunit/phpunit` version `7.*`
- Include `~3.6.0` of `orchestra/testbench`