### PR TITLE
Update badge alt text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Make a Laravel app respond to a slash command from Slack
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/spatie/laravel-slack-slash-command.svg?style=flat-square)](https://packagist.org/packages/spatie/laravel-slack-slash-command)
-[![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
+[![MIT Licensed](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
 [![Build Status](https://img.shields.io/travis/spatie/laravel-slack-slash-command/master.svg?style=flat-square)](https://travis-ci.org/spatie/laravel-slack-slash-command)
 [![Quality Score](https://img.shields.io/scrutinizer/g/spatie/laravel-slack-slash-command.svg?style=flat-square)](https://scrutinizer-ci.com/g/spatie/laravel-slack-slash-command)
 [![StyleCI](https://styleci.io/repos/62377978/shield?branch=master)](https://styleci.io/repos/62377978)


### PR DESCRIPTION
If the bade doesn't load, this will still allow users to see what the license is. It is also beneficial for users who use screen readers.

See also: https://github.com/spatie/laravel-sluggable/pull/107