### PR TITLE
Add default parameter for respondToSlack() method

### DIFF
--- a/src/Handlers/BaseHandler.php
+++ b/src/Handlers/BaseHandler.php
@@ -22,7 +22,7 @@ abstract class BaseHandler implements HandlesSlashCommand
         $this->request = $request;
     }
 
-    public function respondToSlack(string $text): Response
+    public function respondToSlack(string $text = ''): Response
     {
         return Response::create($this->request)->withText($text);
     }

--- a/src/HandlesSlashCommand.php
+++ b/src/HandlesSlashCommand.php
@@ -6,5 +6,5 @@ interface HandlesSlashCommand
 {
     public function getRequest(): Request;
 
-    public function respondToSlack(string $text): Response;
+    public function respondToSlack(string $text = ''): Response;
 }

--- a/src/Jobs/SlashCommandResponseJob.php
+++ b/src/Jobs/SlashCommandResponseJob.php
@@ -24,7 +24,7 @@ abstract class SlashCommandResponseJob implements ShouldQueue, HandlesSlashComma
         return $this;
     }
 
-    public function respondToSlack(string $text): Response
+    public function respondToSlack(string $text = ''): Response
     {
         return $this->getResponse()->withText($text);
     }


### PR DESCRIPTION
When follow the sample on docs, it thrown an error, because `respondToSlack()` must have an argument. This PR add empty string as default parameter to `respondToSlack()`.

Related to https://github.com/spatie/laravel-slack-slash-command/pull/89