### PR TITLE
Docs: Remove variable reference from message in signature

### DIFF
--- a/docs/advanced-usage/using-signature-handlers.md
+++ b/docs/advanced-usage/using-signature-handlers.md
@@ -18,7 +18,7 @@ use Spatie\SlashCommand\Handlers\SignatureHandler;
 
 class SendEmail extends SignatureHandler
 {
-    protected $signature = "your-command email:send {to} {$message} {--queue}";
+    protected $signature = "your-command email:send {to} {message} {--queue}";
     
     protected $description = "A description of what your command does. This text will be displayed in the help command.";
 


### PR DESCRIPTION
The $ caused an error when used. It should just be a placeholder not variable.