### PR TITLE
Laravel 8 & Guzzle 7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 7.2
   - 7.3
   - 7.4
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 7.2
   - 7.3
+  - 7.4
 
 env:
   matrix:

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require-dev": {
         "mockery/mockery": "^1.0",
         "orchestra/testbench":  "~3.8.0|^4.0|^5.0",
-        "phpunit/phpunit": "^8.0"
+        "phpunit/phpunit": "^9.2"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php" : "^7.2",
+        "php" : "^7.3",
         "illuminate/support": "~5.8.0|^6.0|^7.0|^8.0",
         "illuminate/routing": "~5.8.0|^6.0|^7.0|^8.0",
         "illuminate/config": "~5.8.0|^6.0|^7.0|^8.0",

--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,11 @@
     ],
     "require": {
         "php" : "^7.2",
-        "illuminate/support": "~5.8.0|^6.0|^7.0",
-        "illuminate/routing": "~5.8.0|^6.0|^7.0",
-        "illuminate/config": "~5.8.0|^6.0|^7.0",
-        "illuminate/queue": "~5.8.0|^6.0|^7.0",
-        "guzzlehttp/guzzle": "^6.3",
+        "illuminate/support": "~5.8.0|^6.0|^7.0|^8.0",
+        "illuminate/routing": "~5.8.0|^6.0|^7.0|^8.0",
+        "illuminate/config": "~5.8.0|^6.0|^7.0|^8.0",
+        "illuminate/queue": "~5.8.0|^6.0|^7.0|^8.0",
+        "guzzlehttp/guzzle": "^7.0",
         "laravel/helpers": "^1.0"
 
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,22 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="Spatie Test Suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Spatie Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>


### PR DESCRIPTION
- Bump illuminate components to ^8.0
- Bump guzzle to ^7.0
- Added php 7.4 to tested versions
- Drop php 7.2 from supported versions