### PR TITLE
Allowed PHP Version ^7.3|^8.0 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php" : "^7.3",
+        "php" : "^7.3|^8.0",
         "illuminate/support": "~5.8.0|^6.0|^7.0|^8.0",
         "illuminate/routing": "~5.8.0|^6.0|^7.0|^8.0",
         "illuminate/config": "~5.8.0|^6.0|^7.0|^8.0",


### PR DESCRIPTION
## Overview
I changed the required PHP Version in `composer.json` to allow PHP 8 by setting the value to `^7.3|^8.0`. This should allow the package to work in PHP versions `>= 7.3` and `>= 8.0`.

Note: I am very unsure what branch this should merge to, so I just set it to `master` 🤷 

## Testing Steps
- [x] `composer install` using PHP 7.4 (my old env)
- [x] `composer install` using PHP 8.0 (my new env)
- [ ] What other tests are run on a release?