### PR TITLE
Remove unnecessary array access to config value

### DIFF
--- a/src/SlashCommandServiceProvider.php
+++ b/src/SlashCommandServiceProvider.php
@@ -15,7 +15,7 @@ class SlashCommandServiceProvider extends ServiceProvider
             __DIR__.'/../config/laravel-slack-slash-command.php' => config_path('laravel-slack-slash-command.php'),
         ], 'config');
 
-        $this->app['router']->post(config('laravel-slack-slash-command')['url'], Controller::class.'@getResponse');
+        $this->app['router']->post(config('laravel-slack-slash-command.url'), Controller::class.'@getResponse');
     }
 
     /**


### PR DESCRIPTION
The previous approach creates errors if config caching is used when installing via composer.

As this is a service provider, it breaks every Artisan command and you cannot clear the config cache.

The previous approach works if `php artisan config:clear` was ran before installing this package, otherwise errors:
```php
> @php artisan package:discover --ansi

   ErrorException 

  Trying to access array offset on value of type null

  at vendor/spatie/laravel-slack-slash-command/src/SlashCommandServiceProvider.php:18
     14▕         $this->publishes([
     15▕             __DIR__.'/../config/laravel-slack-slash-command.php' => config_path('laravel-slack-slash-command.php'),
     16▕         ], 'config');
     17▕ 
  ➜  18▕         $this->app['router']->post(config('laravel-slack-slash-command')['url'], Controller::class.'@getResponse');
     19▕     }
     20▕ 
     21▕     /**
     22▕      * Register the application services.

      +8 vendor frames 
  9   [internal]:0
      Illuminate\Foundation\Application::Illuminate\Foundation\{closure}()

      +5 vendor frames 
  15  artisan:37
      Illuminate\Foundation\Console\Kernel::handle()
Script @php artisan package:discover --ansi handling the post-autoload-dump event returned with error code 1
```