### PR TITLE
Add Laravel 9 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,18 +16,17 @@
         }
     ],
     "require": {
-        "php" : "^7.3|^8.0",
-        "illuminate/support": "~5.8.0|^6.0|^7.0|^8.0",
-        "illuminate/routing": "~5.8.0|^6.0|^7.0|^8.0",
-        "illuminate/config": "~5.8.0|^6.0|^7.0|^8.0",
-        "illuminate/queue": "~5.8.0|^6.0|^7.0|^8.0",
+        "php": "^7.3|^8.0",
+        "illuminate/support": "~5.8.0|^6.0|^7.0|^8.0|^9.0",
+        "illuminate/routing": "~5.8.0|^6.0|^7.0|^8.0|^9.0",
+        "illuminate/config": "~5.8.0|^6.0|^7.0|^8.0|^9.0",
+        "illuminate/queue": "~5.8.0|^6.0|^7.0|^8.0|^9.0",
         "guzzlehttp/guzzle": "^7.0",
         "laravel/helpers": "^1.0"
-
     },
     "require-dev": {
         "mockery/mockery": "^1.0",
-        "orchestra/testbench":  "~3.8.0|^4.0|^5.0",
+        "orchestra/testbench": "~3.8.0|^4.0|^5.0|^6.0|^7.0",
         "phpunit/phpunit": "^9.2"
     },
     "autoload": {


### PR DESCRIPTION
This PR simply bumps the composer dependencies to add Laravel 9 support.

I ran the existing test suite locally and everything passed, however I didn't pull this into a real project for testing.

Let me know if there's any questions/feedback. Thanks!