### PR TITLE
Remove unused `laravel/helpers` dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,7 @@
         "illuminate/routing": "~5.8.0|^6.0|^7.0|^8.0|^9.0|^10.0",
         "illuminate/config": "~5.8.0|^6.0|^7.0|^8.0|^9.0|^10.0",
         "illuminate/queue": "~5.8.0|^6.0|^7.0|^8.0|^9.0|^10.0",
-        "guzzlehttp/guzzle": "^7.0",
-        "laravel/helpers": "^1.0"
+        "guzzlehttp/guzzle": "^7.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",


### PR DESCRIPTION
Terminal command to check for `laravel/helpers` usage in all PHP files:

```shell
grep -r -o -w -h -n -E 'array_add|array_collapse|array_divide|array_dot|array_except|array_first|array_flatten|array_forget|array_get|array_has|array_last|array_only|array_pluck|array_prepend|array_pull|array_random|array_set|array_sort|array_sort_recursive|array_where|array_wrap|camel_case|ends_with|kebab_case|snake_case|starts_with|str_after|str_before|str_contains|str_finish|str_is|str_limit|str_plural|str_random|str_replace_array|str_replace_first|str_replace_last|str_singular|str_slug|str_start|studly_case|title_case' **.php
```

--- 

Fun fact: this is the last package from Spatie that has the helpers package :)
https://grep.app/search?q=laravel/helpers&filter[repo.pattern][0]=spatie