### PR TITLE
Composer package name updated

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "spatie/laravel-slack-slash-command-slash-command",
+    "name": "spatie/laravel-slack-slash-command",
     "description": "Make a Laravel app respond to a slash command from Slack",
     "keywords": [
         "spatie",


### PR DESCRIPTION
`composer.json` has invalid library name. This PR fixes that.

Because of that I cannot use a fork with Laravel 11 upgrade from Shift (#114), but of course it's good to have a proper name in your repository. :)