### PR TITLE
Allow to acknowledge with an empty response to Slack

### DIFF
--- a/docs/advanced-usage/sending-delayed-responses.md
+++ b/docs/advanced-usage/sending-delayed-responses.md
@@ -72,3 +72,14 @@ class SlowApiJobJob extends SlashCommandResponseJob
 When a user types in `/your-command get me the info` a quick response `Looking that info for you...` will be displayed. After a little while, when `MyApi` has done it's job `Here is your response: ...` will be sent to the channel.
 
 Notice that, unlike in the `Handlers` you'll need to call `send()` after the `respondToSlack`-method. You may send up to five responses in a timespan of 30 minutes in this job.
+
+You can also avoid sending a response in the handler and rely on responses send in the job only. Do remember to give early feedback to users.
+
+```php
+    public function handle(Request $request): Response
+    {
+        $this->dispatch(new ComplexJob());
+    
+        return $this->acknowledgeToSlack();
+    }
+```

--- a/docs/usage/sending-a-basic-response.md
+++ b/docs/usage/sending-a-basic-response.md
@@ -122,3 +122,12 @@ By default the response will be sent to the user who typed in the original messa
 ```
 
 There are a lot of ways to format your message. Take a look at the docs on [formatting responses](https://docs.spatie.be/laravel-slack-slash-command/v1/usage/making-your-response-look-good) to learn more.
+
+You can also avoid sending a response in text directly. This can be useful if you want to interact with Slack API directly or have another way of providing feedback to users. Do remember to give feedback to users.
+
+```php
+    public function handle(Request $request): Response
+    {
+        return $this->acknowledgeToSlack();
+    }
+```

--- a/src/Handlers/BaseHandler.php
+++ b/src/Handlers/BaseHandler.php
@@ -27,6 +27,11 @@ abstract class BaseHandler implements HandlesSlashCommand
         return Response::create($this->request)->withText($text);
     }
 
+    public function acknowledgeToSlack(): Response
+    {
+        return Response::create($this->request);
+    }
+
     protected function dispatch(SlashCommandResponseJob $job)
     {
         $job->setRequest($this->request);

--- a/src/Response.php
+++ b/src/Response.php
@@ -161,6 +161,10 @@ class Response
 
     public function getIlluminateResponse(): IlluminateResponse
     {
+        if (isset($this->text) === false) {
+            return new IlluminateResponse();
+        }
+
         return new IlluminateResponse($this->getPayload());
     }
 

--- a/tests/Handlers/BaseHandlerTest.php
+++ b/tests/Handlers/BaseHandlerTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Spatie\SlashCommand\Test\Handlers;
+
+use Spatie\SlashCommand\Exceptions\InvalidHandler;
+use Spatie\SlashCommand\Handlers\BaseHandler;
+use Spatie\SlashCommand\Request;
+use Spatie\SlashCommand\Response;
+
+function getPostParametersForBaseHandler(array $mergeVariables = []): array
+{
+    return array_merge([
+        'token' => 'test-token',
+        'team_id' => 'T123',
+        'team_domain' => 'Company',
+        'channel_id' => 'C123',
+        'channel_name' => 'General',
+        'user_id' => 'U123',
+        'user_name' => 'Bob',
+        'command' => '/commandName',
+        'text' => 'handlerName my-argument --option',
+        'response_url' => 'https://slack.com/respond',
+    ], $mergeVariables);
+}
+
+beforeEach(function () {
+    $illuminateRequest = $this->getIlluminateRequest(getPostParametersForBaseHandler());
+
+    $this->request = Request::createFromIlluminateRequest($illuminateRequest);
+});
+
+it('can handle requests if allowed', function () {
+    $baseHandler = new class($this->request) extends BaseHandler {
+        public function canHandle(Request $request): bool
+        {
+            return true;
+        }
+
+        public function handle(Request $request): Response
+        {
+            return true;
+        }
+    };
+
+    expect($baseHandler->canHandle($this->request))->toBeTrue();
+});
+
+it('cannot handle requests if disallowed', function () {
+    $baseHandler = new class($this->request) extends BaseHandler {
+        public function canHandle(Request $request): bool
+        {
+            return false;
+        }
+
+        public function handle(Request $request): Response
+        {
+            return true;
+        }
+    };
+
+    expect($baseHandler->canHandle($this->request))->toBeFalse();
+});
+
+it('can respond with text', function () {
+    $baseHandler = new class($this->request) extends BaseHandler {
+        public function canHandle(Request $request): bool
+        {
+            return true;
+        }
+
+        public function handle(Request $request): Response
+        {
+            return $this->respondToSlack('Testing 123');
+        }
+    };
+
+    $response = $baseHandler->handle($this->request)->getIlluminateResponse();
+
+    expect($response->getStatusCode())->toBe(200);
+    expect($response->getContent())->toBeJson();
+    expect(json_decode($response->getContent(), associative: true)['text'])->toBe('Testing 123');
+});

--- a/tests/Handlers/BaseHandlerTest.php
+++ b/tests/Handlers/BaseHandlerTest.php
@@ -80,3 +80,23 @@ it('can respond with text', function () {
     expect($response->getContent())->toBeJson();
     expect(json_decode($response->getContent(), associative: true)['text'])->toBe('Testing 123');
 });
+
+it('can respond with an empty body', function () {
+    $baseHandler = new class($this->request) extends BaseHandler {
+        public function canHandle(Request $request): bool
+        {
+            return true;
+        }
+
+        public function handle(Request $request): Response
+        {
+            return $this->acknowledgeToSlack();
+        }
+    };
+
+    $response = $baseHandler->handle($this->request)->getIlluminateResponse();
+
+    expect($response->getStatusCode())->toBe(200);
+    expect($response->getContent())->toBeString();
+    expect($response->getContent())->toBeEmpty();
+});


### PR DESCRIPTION
You can reply to Slack in other ways than sending text. One of those is an empty response, see https://docs.slack.dev/interactivity/implementing-slash-commands/#responding_basic_receipt. Slack docs calls this 'acknowledge' or 'confirm'. This PR allows to use that as well.

My use case is that I want to talk to Slack's API directly, for a more rich interaction. For instance to receive the message id (`ts`) to be able to send replies as well.

Another use case is that you're using delayed responses and have quick responses in the job. If so the response in the handler and the one in the job will arrive at Slack at randomly different times. To avoid this you can move all responses to the job, but then you need an empty response in the handler.

Welcome for feedback in approach, tests, docs!